### PR TITLE
sfneal/address composer requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,7 @@ All notable changes to `mock-models` will be documented in this file
 
 ## 0.2.0 - 2021-04-20
 - make Utils\Interfaces & Utils\Traits namespaces for testing tools
+
+
+## 0.2.1 - 2021-04-20
+- fix sfneal/address composer requirement to allow for 'dev' & 'master' branch installations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ All notable changes to `mock-models` will be documented in this file
 
 ## 0.2.1 - 2021-04-20
 - fix sfneal/address composer requirement to allow for 'dev' & 'master' branch installations
+- add $eventsToFake param to `EventFaker` trait's `eventFaker()` method

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/address": "^1.2.2",
+        "sfneal/address": "^1.2.2|dev-dev|dev-master",
         "sfneal/models": "^2.2"
     },
     "require-dev": {

--- a/src/Utils/Traits/EventFaker.php
+++ b/src/Utils/Traits/EventFaker.php
@@ -9,12 +9,13 @@ trait EventFaker
     /**
      * Setup Event faking.
      *
+     * @param  array|string  $eventsToFake
      * @return void
      */
-    protected function eventFaker(): void
+    protected function eventFaker($eventsToFake = []): void
     {
         // Enable event faking
-        Event::fake();
+        Event::fake($eventsToFake);
 
         // Assert that no events were dispatched...
         Event::assertNothingDispatched();


### PR DESCRIPTION
- fix sfneal/address composer requirement to allow for 'dev' & 'master' branch installations
- add $eventsToFake param to `EventFaker` trait's `eventFaker()` method