### PR TITLE
sfneal/address allow any 'dev-' branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ All notable changes to `mock-models` will be documented in this file
 ## 0.2.1 - 2021-04-20
 - fix sfneal/address composer requirement to allow for 'dev' & 'master' branch installations
 - add $eventsToFake param to `EventFaker` trait's `eventFaker()` method
+
+
+## 0.2.2 - 2021-04-20
+- fix sfneal/address composer requirement to allow any 'dev-' branch

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "sfneal/address": "^1.2.2|dev-dev|dev-master",
+        "sfneal/address": "^1.2.2|dev-*",
         "sfneal/models": "^2.2"
     },
     "require-dev": {


### PR DESCRIPTION
- fix sfneal/address composer requirement to allow any 'dev-' branch