### PR TITLE
`RequestCreator` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,8 @@ All notable changes to `mock-models` will be documented in this file
 
 ## 0.2.2 - 2021-04-20
 - fix sfneal/address composer requirement to allow any 'dev-' branch
+
+
+## 0.3.0 - 2021-04-21
+- make `RequestCreator` interface for implementing custom request creators in test suites
+- add tests for `CreateRequest`, `EventFaker` & `QueueFaker` traits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ All notable changes to `mock-models` will be documented in this file
 ## 0.3.0 - 2021-04-21
 - make `RequestCreator` interface for implementing custom request creators in test suites
 - add tests for `CreateRequest`, `EventFaker` & `QueueFaker` traits
+- add laravel/framework min version v8.34 composer requirement

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.3",
+        "laravel/framework": ">=8.34",
         "sfneal/address": "^1.2.2|dev-*",
         "sfneal/models": "^2.2"
     },

--- a/src/Utils/Interfaces/RequestCreator.php
+++ b/src/Utils/Interfaces/RequestCreator.php
@@ -1,10 +1,12 @@
 <?php
 
-namespace Sfneal\Testing\Utils\Traits;
+
+namespace Sfneal\Testing\Utils\Interfaces;
+
 
 use Illuminate\Http\Request;
 
-trait CreateRequest
+interface RequestCreator
 {
     /**
      * Create a Request to be used in test methods.
@@ -22,14 +24,5 @@ trait CreateRequest
                                   array $cookies = [],
                                   array $files = [],
                                   array $server = [],
-                                  $content = null): Request
-    {
-        $request = Request::create('/', 'GET', $parameters, $cookies, $files, $server, $content);
-
-        foreach ($headers as $header => $value) {
-            $request->headers->set($header, $value);
-        }
-
-        return $request;
-    }
+                                  $content = null): Request;
 }

--- a/src/Utils/Interfaces/RequestCreator.php
+++ b/src/Utils/Interfaces/RequestCreator.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Testing\Utils\Interfaces;
-
 
 use Illuminate\Http\Request;
 

--- a/src/Utils/Traits/CreateRequest.php
+++ b/src/Utils/Traits/CreateRequest.php
@@ -17,7 +17,12 @@ trait CreateRequest
      * @param null $content
      * @return Request
      */
-    protected function createRequest(array $headers = [], array $parameters = [], array $cookies = [], array $files = [], array $server = [], $content = null): Request
+    protected function createRequest(array $headers = [],
+                                     array $parameters = [],
+                                     array $cookies = [],
+                                     array $files = [],
+                                     array $server = [],
+                                     $content = null): Request
     {
         $request = Request::create('/', 'GET', $parameters, $cookies, $files, $server, $content);
 

--- a/tests/CreateRequestTest.php
+++ b/tests/CreateRequestTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Testing\Tests;
-
 
 use Illuminate\Http\Request;
 use Sfneal\Testing\Utils\Interfaces\RequestCreator;

--- a/tests/CreateRequestTest.php
+++ b/tests/CreateRequestTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Sfneal\Testing\Tests;
+
+
+use Illuminate\Http\Request;
+use Sfneal\Testing\Utils\Interfaces\RequestCreator;
+use Sfneal\Testing\Utils\Traits\CreateRequest;
+
+class CreateRequestTest extends TestCase implements RequestCreator
+{
+    use CreateRequest;
+
+    /** @test */
+    public function request_can_be_created()
+    {
+        $request = $this->createRequest();
+
+        $this->assertNotNull($request);
+        $this->assertInstanceOf(Request::class, $request);
+    }
+}

--- a/tests/EventFakingTest.php
+++ b/tests/EventFakingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Sfneal\Testing\Tests;
+
+
+use Illuminate\Support\Facades\Event;
+use Sfneal\Testing\Utils\Traits\EventFaker;
+
+class EventFakingTest extends TestCase
+{
+    use EventFaker;
+
+    /** @test */
+    public function events_can_be_faked()
+    {
+        $this->eventFaker();
+
+        Event::assertNothingDispatched();
+    }
+}

--- a/tests/EventFakingTest.php
+++ b/tests/EventFakingTest.php
@@ -2,6 +2,7 @@
 
 namespace Sfneal\Testing\Tests;
 
+use Illuminate\Support\Facades\Event;
 use Sfneal\Testing\Utils\Traits\EventFaker;
 
 class EventFakingTest extends TestCase
@@ -12,5 +13,7 @@ class EventFakingTest extends TestCase
     public function events_can_be_faked()
     {
         $this->eventFaker();
+
+        Event::assertNothingDispatched();
     }
 }

--- a/tests/EventFakingTest.php
+++ b/tests/EventFakingTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Testing\Tests;
 
-use Illuminate\Support\Facades\Event;
 use Sfneal\Testing\Utils\Traits\EventFaker;
 
 class EventFakingTest extends TestCase
@@ -13,7 +12,5 @@ class EventFakingTest extends TestCase
     public function events_can_be_faked()
     {
         $this->eventFaker();
-
-        Event::assertNothingDispatched();
     }
 }

--- a/tests/EventFakingTest.php
+++ b/tests/EventFakingTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Testing\Tests;
-
 
 use Illuminate\Support\Facades\Event;
 use Sfneal\Testing\Utils\Traits\EventFaker;

--- a/tests/QueueFakingTest.php
+++ b/tests/QueueFakingTest.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Sfneal\Testing\Tests;
+
+
+use Illuminate\Support\Facades\Queue;
+use Sfneal\Testing\Utils\Traits\QueueFaker;
+
+class QueueFakingTest extends TestCase
+{
+    use QueueFaker;
+
+    /** @test */
+    public function events_can_be_faked()
+    {
+        $this->queueFaker();
+
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/QueueFakingTest.php
+++ b/tests/QueueFakingTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Testing\Tests;
-
 
 use Illuminate\Support\Facades\Queue;
 use Sfneal\Testing\Utils\Traits\QueueFaker;


### PR DESCRIPTION
- make `RequestCreator` interface for implementing custom request creators in test suites
- add tests for `CreateRequest`, `EventFaker` & `QueueFaker` traits
- add laravel/framework min version v8.34 composer requirement