### PR TITLE
refactor `ModelAttributeAssertions` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,7 @@ All notable changes to `mock-models` will be documented in this file
 ## 0.3.1 - 2021-04-22
 - add registering of the `AddressServiceProvider` to `MockModelsServiceProvider`
 - cut sfneal/address dev-master allowed version
+
+
+## 0.4.0 - 2021-04-26
+- refactor `ModelAttributeAssertions` traits methods into `assertModelAttributesSame()` & `assertModelAttributesEqual()` methods

--- a/src/Utils/Traits/ModelAttributeAssertions.php
+++ b/src/Utils/Traits/ModelAttributeAssertions.php
@@ -7,17 +7,48 @@ use Illuminate\Database\Eloquent\Model;
 trait ModelAttributeAssertions
 {
     /**
-     * Execute model assertions.
+     * Assert model attributes are same.
      *
      * @param array $data
      * @param Model $model
-     * @param string $assertionMethod
+     * @param array|null $ignoredAttributes
      * @return void
      */
-    private function modelAttributeAssertions(array $data, Model $model, string $assertionMethod = 'assertSame'): void
+    public static function assertModelAttributesSame(array $data, Model $model, array $ignoredAttributes = null): void
     {
+        // Remove ignore attributes
+        if (isset($ignoredAttributes)) {
+            foreach ($ignoredAttributes as $attribute) {
+                unset($data[$attribute]);
+            }
+        }
+
+        // Execute assertions on each attribute
         foreach ($data as $attribute => $value) {
-            $this->{$assertionMethod}($value, $model->{$attribute});
+            self::assertSame($value, $model->{$attribute});
+        }
+    }
+
+    /**
+     * Assert model attributes are equal.
+     *
+     * @param array $data
+     * @param Model $model
+     * @param array|null $ignoredAttributes
+     * @return void
+     */
+    public static function assertModelAttributesEqual(array $data, Model $model, array $ignoredAttributes = null): void
+    {
+        // Remove ignore attributes
+        if (isset($ignoredAttributes)) {
+            foreach ($ignoredAttributes as $attribute) {
+                unset($data[$attribute]);
+            }
+        }
+
+        // Execute assertions on each attribute
+        foreach ($data as $attribute => $value) {
+            self::assertEquals($value, $model->{$attribute});
         }
     }
 }

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -27,6 +27,6 @@ class MigrationsTest extends TestCase
         $newPerson = People::query()->find($person->person_id);
 
         // Assert Jokes are the same
-        $this->modelAttributeAssertions($data, $newPerson);
+        $this->assertModelAttributesSame($data, $newPerson);
     }
 }


### PR DESCRIPTION
- refactor `ModelAttributeAssertions` traits methods into `assertModelAttributesSame()` & `assertModelAttributesEqual()` methods