### PR TITLE
Fix sfneal/address min version to v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,3 +61,7 @@ All notable changes to `mock-models` will be documented in this file
 ## 0.9.1 - 2021-08-04
 - make `AssertArrayValues` trait with custom assertion methods
 - add 'ext-json' to composer requirements
+
+
+## 0.9.2 - 2021-08-18
+- fix sfneal/address min version to v1.2 since broken v1.2.0 & v1.2.1 versions have been removed

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "orchestra/testbench": ">=6.7.1",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/address": "^1.2.2"
+        "sfneal/address": "^1.2"
     },
     "suggest": {
         "sfneal/address": "Allows for use of `People` model's 'address' relationship"


### PR DESCRIPTION
- fix sfneal/address min version to v1.2 since broken v1.2.0 & v1.2.1 versions have been removed