### PR TITLE
`AddressServiceProvider` Registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,7 @@ All notable changes to `mock-models` will be documented in this file
 
 ## 0.10.0 - 2022-01-31
 - add new `WithMemoryDbConnection` & `WithResponse` test case traits
+
+
+## 0.10.1 - 2022-01-31
+- fix issue with registering `AddressServiceProvider` when the 'sfneal/address' package isn't installed

--- a/src/Providers/MockModelsServiceProvider.php
+++ b/src/Providers/MockModelsServiceProvider.php
@@ -31,6 +31,9 @@ class MockModelsServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->register(AddressServiceProvider::class);
+        // Only register provider if 'sfneal/address' is installed
+        if (class_exists(AddressServiceProvider::class)) {
+            $this->app->register(AddressServiceProvider::class);
+        }
     }
 }


### PR DESCRIPTION
- fix issue with registering `AddressServiceProvider` when the 'sfneal/address' package isn't installed